### PR TITLE
ODD-572: Provide unified, docker-based builds with version tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /target
 /bin/
 /.apt_generated/
+*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: python
+language: java
 
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+
+sudo: required
+
+services:
+  - docker
+
+before_install:
+  - cd docker && bash ./dockbuild.sh
+
+script:
+  - bash ./testall

--- a/docker/build-test/Dockerfile
+++ b/docker/build-test/Dockerfile
@@ -34,6 +34,7 @@ RUN grep -qs ":${devuid}:[[:digit:]]+:" /etc/passwd || \
 RUN mkdir /home/$devuser/.m2
 
 VOLUME /app/dev
+VOLUME /app/dist
 COPY settings.xml /app/mvn-user-settings.xml
 COPY settings.xml /home/$devuser/.m2/settings.xml
 RUN chown $devuser:$devuser /home/$devuser/.m2/settings.xml && \

--- a/docker/build-test/Dockerfile
+++ b/docker/build-test/Dockerfile
@@ -3,21 +3,19 @@ FROM maven:3.5-jdk-8-alpine
 RUN  apk update && apk upgrade && apk add netcat-openbsd zip git less \
                                           gnupg shadow python
 
-ARG gosu_arch=
-ENV GOSU_ARCH $gosu_arch
-ENV GOSU_VERSION 1.10
-RUN set -ex; [ -n "$GOSU_ARCH" ] || arch=$(uname -r | awk -F- '{print $NF}'); \
-    wget -O /usr/local/bin/gosu \
-   "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$GOSU_ARCH"; \
-    wget -O /usr/local/bin/gosu.asc \
-"https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$GOSU_ARCH.asc";\
-    export GNUPGHOME="$(mktemp -d)"; \
-    gpg --keyserver ha.pool.sks-keyservers.net \
-         --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-    sleep 1; rm -r /usr/local/bin/gosu.asc "$GNUPGHOME" || true; \
-    chmod +x /usr/local/bin/gosu; \
-    gosu nobody true
+# ENV GOSU_VERSION 1.10
+# RUN set -ex; arch=amd64; \
+#     wget -O /usr/local/bin/gosu \
+#    "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$arch"; \
+#     wget -O /usr/local/bin/gosu.asc \
+# "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$arch.asc";\
+#     export GNUPGHOME="$(mktemp -d)"; \
+#     gpg --keyserver ha.pool.sks-keyservers.net \
+#          --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+#     gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+#     sleep 1; rm -r /usr/local/bin/gosu.asc "$GNUPGHOME" || true; \
+#     chmod +x /usr/local/bin/gosu; \
+#     gosu nobody true
 
 # Create the user that build/test operations should run as.  Normally,
 # this is set to match identity information of the host user that is

--- a/docker/build-test/Dockerfile
+++ b/docker/build-test/Dockerfile
@@ -3,18 +3,19 @@ FROM maven:3.5-jdk-8-alpine
 RUN  apk update && apk upgrade && apk add netcat-openbsd zip git less \
                                           gnupg shadow
 
+ARG gosu_arch=
+ENV GOSU_ARCH $gosu_arch
 ENV GOSU_VERSION 1.10
-RUN set -ex; \
-    arch="$(uname -r | sed -e 's/.*-//')"; \
+RUN set -ex; [ -n "$GOSU_ARCH" ] || arch=$(uname -r | awk -F- '{print $NF}'); \
     wget -O /usr/local/bin/gosu \
-   "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$arch"; \
+   "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$GOSU_ARCH"; \
     wget -O /usr/local/bin/gosu.asc \
-"https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$arch.asc";\
+"https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$GOSU_ARCH.asc";\
     export GNUPGHOME="$(mktemp -d)"; \
     gpg --keyserver ha.pool.sks-keyservers.net \
          --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
     gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-    rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+    sleep 1; rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
     chmod +x /usr/local/bin/gosu; \
     gosu nobody true
 

--- a/docker/build-test/Dockerfile
+++ b/docker/build-test/Dockerfile
@@ -1,7 +1,7 @@
 FROM maven:3.5-jdk-8-alpine
 
 RUN  apk update && apk upgrade && apk add netcat-openbsd zip git less \
-                                          gnupg shadow
+                                          gnupg shadow python
 
 ARG gosu_arch=
 ENV GOSU_ARCH $gosu_arch

--- a/docker/build-test/Dockerfile
+++ b/docker/build-test/Dockerfile
@@ -1,0 +1,47 @@
+FROM maven:3.5-jdk-8-alpine
+
+RUN  apk update && apk upgrade && apk add netcat-openbsd zip git less \
+                                          gnupg shadow
+
+ENV GOSU_VERSION 1.10
+RUN set -ex; \
+    arch="$(uname -r | sed -e 's/.*-//')"; \
+    wget -O /usr/local/bin/gosu \
+   "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$arch"; \
+    wget -O /usr/local/bin/gosu.asc \
+"https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$arch.asc";\
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --keyserver ha.pool.sks-keyservers.net \
+         --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+    rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+    chmod +x /usr/local/bin/gosu; \
+    gosu nobody true
+
+# Create the user that build/test operations should run as.  Normally,
+# this is set to match identity information of the host user that is
+# launching the container.
+#
+RUN sed --in-place -e '/CREATE_MAIL_SPOOL/ s/=yes/=no/' /etc/default/useradd
+ARG devuser=developer
+ARG devuid=1000
+RUN grep -qs :${devuid}: /etc/group || \
+    groupadd --gid $devuid $devuser
+RUN grep -qs ":${devuid}:[[:digit:]]+:" /etc/passwd || \
+    useradd -m --comment "OAR Developer" --shell /bin/bash \
+            --gid $devuid --uid $devuid $devuser
+RUN mkdir /home/$devuser/.m2
+
+VOLUME /app/dev
+COPY settings.xml /app/mvn-user-settings.xml
+COPY settings.xml /home/$devuser/.m2/settings.xml
+RUN chown $devuser:$devuser /home/$devuser/.m2/settings.xml && \
+    chmod a+r /home/$devuser/.m2/settings.xml
+COPY entrypoint.sh /app/entrypoint.sh
+RUN chmod a+rx /app/entrypoint.sh
+
+WORKDIR /app/dev
+USER $devuser
+ENTRYPOINT [ "/app/entrypoint.sh" ]
+
+

--- a/docker/build-test/Dockerfile
+++ b/docker/build-test/Dockerfile
@@ -15,7 +15,7 @@ RUN set -ex; [ -n "$GOSU_ARCH" ] || arch=$(uname -r | awk -F- '{print $NF}'); \
     gpg --keyserver ha.pool.sks-keyservers.net \
          --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
     gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-    sleep 1; rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+    sleep 1; rm -r /usr/local/bin/gosu.asc "$GNUPGHOME" || true; \
     chmod +x /usr/local/bin/gosu; \
     gosu nobody true
 

--- a/docker/build-test/entrypoint.sh
+++ b/docker/build-test/entrypoint.sh
@@ -1,0 +1,20 @@
+#! /bin/bash
+#
+[ "$1" = "" ] && exec /bin/bash
+
+case "$1" in
+    makedist)
+        scripts/makedist
+        ;;
+    testall)
+        scripts/testall
+        ;;
+    shell)
+        exec /bin/bash
+        ;;
+    *)
+        echo Unknown command: $1
+        echo Available commands makedist testall shell
+        ;;
+esac
+

--- a/docker/build-test/entrypoint.sh
+++ b/docker/build-test/entrypoint.sh
@@ -4,10 +4,12 @@
 
 case "$1" in
     makedist)
-        scripts/makedist
+        shift
+        scripts/makedist "$@"
         ;;
     testall)
-        scripts/testall
+        shift
+        scripts/testall "$@"
         ;;
     shell)
         exec /bin/bash

--- a/docker/build-test/settings.xml
+++ b/docker/build-test/settings.xml
@@ -1,0 +1,5 @@
+<settings>
+
+  <localRepository>/app/dev/m2repo/</localRepository>
+
+</settings>

--- a/docker/dockbuild.sh
+++ b/docker/dockbuild.sh
@@ -1,0 +1,39 @@
+#! /bin/bash
+#
+# buildall.sh:  build all docker images in this directory
+#
+# Usage: buildall.sh
+#
+prog=`basename $0`
+execdir=`dirname $0`
+[ "$execdir" = "" -o "$execdir" = "." ] && execdir=$PWD
+codedir=`(cd $execdir/.. > /dev/null 2>&1; pwd)`
+set -e
+
+## These are set by default via _run.sh; if necessary, uncomment and customize
+#
+# PACKAGE_NAME=oar-build
+# 
+## list the names of the image directories (each containing a Dockerfile) for
+## containers to be built.  List them in dependency order (where a latter one
+## depends the former ones).  
+#
+DOCKER_IMAGE_DIRS="build-test"
+
+. $codedir/oar-build/_dockbuild.sh
+
+# Override, if need be, the UID of the user to run as in the container; the 
+# default is the user running this script.
+#
+# OAR_DOCKER_UID=
+
+# set BUILD_OPTS and BUILD_IMAGES
+# 
+setup_build
+
+log_intro   # record start of build into log
+
+for container in $BUILD_IMAGES; do 
+    echo '+ ' docker build $BUILD_OPTS -t $PACKAGE_NAME/$container $container | logit
+    docker build $BUILD_OPTS -t $PACKAGE_NAME/$container $container 2>&1 | logit
+done

--- a/docker/dockbuild.sh
+++ b/docker/dockbuild.sh
@@ -31,12 +31,6 @@ DOCKER_IMAGE_DIRS="build-test"
 # 
 setup_build
 
-dpkg=`which dpkg`
-[ -z "$dpkg" ] || {
-    GOSU_ARCH=$(dpkg --print-architecture | awk -F- '{ print $NF }')
-    BUILD_OPTS="$BUILD_OPTS --build-arg=gosu_arch=$GOSU_ARCH"
-}
-
 log_intro   # record start of build into log
 
 for container in $BUILD_IMAGES; do 

--- a/docker/dockbuild.sh
+++ b/docker/dockbuild.sh
@@ -31,6 +31,12 @@ DOCKER_IMAGE_DIRS="build-test"
 # 
 setup_build
 
+dpkg=`which dpkg`
+[ -z "$dpkg" ] || {
+    GOSU_ARCH=$(dpkg --print-architecture | awk -F- '{ print $NF }')
+    BUILD_OPTS="$BUILD_OPTS --build-arg=gosu_arch=$GOSU_ARCH"
+}
+
 log_intro   # record start of build into log
 
 for container in $BUILD_IMAGES; do 

--- a/docker/makedist
+++ b/docker/makedist
@@ -6,4 +6,4 @@ execdir=`dirname $0`
 export CODEDIR=`(cd $execdir/.. > /dev/null 2>&1; pwd)`
 export DOCKERDIR=$execdir
 
-exec $DOCKERDIR/run.sh makedist
+exec $DOCKERDIR/run.sh makedist "$@"

--- a/docker/makedist
+++ b/docker/makedist
@@ -1,0 +1,9 @@
+#! /bin/bash
+#
+prog=`basename $0`
+execdir=`dirname $0`
+[ "$execdir" = "" -o "$execdir" = "." ] && execdir=$PWD
+export CODEDIR=`(cd $execdir/.. > /dev/null 2>&1; pwd)`
+export DOCKERDIR=$execdir
+
+exec $DOCKERDIR/run.sh makedist

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -23,8 +23,43 @@ image=build-test
 ti=
 (echo "$@" | grep -qs shell) && ti="-ti"
 
-echo docker run $ti --rm -v $codedir:/app/dev $PACKAGE_NAME/$image "$@"
-exec docker run $ti --rm -v $codedir:/app/dev $PACKAGE_NAME/$image "$@"
+distvol=
+distdir=
+cmd=
+args=()
+while [ "$1" != "" ]; do
+    case "$1" in
+        --dist-dir)
+            shift
+            distdir="$1"
+            mkdir -p $distdir
+            distdir=`(cd $distdir > /dev/null 2>&1; pwd)`
+            distvol="-v ${distdir}:/app/dist"
+            args=(${args[@]} "--dist-dir=/app/dist")
+            ;;
+        --dist-dir=*)
+            distdir=`echo $1 | sed -e 's/[^=]*=//'`
+            mkdir -p $distdir
+            distdir=`(cd $distdir > /dev/null 2>&1; pwd)`
+            distvol="-v ${distdir}:/app/dist"
+            args=(${args[@]} "--dist-dir=/app/dist")
+            ;;
+        -*)
+            args=(${args[@]} $1)
+            ;;
+        *)
+            if [ -z "$cmd" ]; then
+                cmd=$1
+            else
+                args=(${args[@]} $1)
+            fi
+            ;;
+    esac
+    shift
+done
+
+echo '+' docker run $ti --rm -v $codedir:/app/dev $distvol $PACKAGE_NAME/$image $cmd "${args[@]}"
+exec docker run $ti --rm -v $codedir:/app/dev $distvol $PACKAGE_NAME/$image $cmd "${args[@]}"
 
 
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,30 @@
+#! /bin/bash
+#
+prog=`basename $0`
+execdir=`dirname $0`
+[ "$execdir" = "" -o "$execdir" = "." ] && execdir=$PWD
+codedir=`(cd $execdir/.. > /dev/null 2>&1; pwd)`
+
+set -e
+
+PACKAGE_NAME=oar-rmm
+image=build-test
+
+(docker images | grep -qs $PACKAGE_NAME/$image) || {
+    echo "${prog}: Docker image $image not found; building now..."
+    echo '+' $execdir/dockbuild.sh -q
+    $execdir/dockbuild.sh -q || {
+        echo "${prog}: Failed to build docker containers; see" \
+             "docker/dockbuild.logfor details."
+        false
+    }
+}
+
+ti=
+(echo "$@" | grep -qs shell) && ti="-ti"
+
+echo docker run $ti --rm -v $codedir:/app/dev $PACKAGE_NAME/$image "$@"
+exec docker run $ti --rm -v $codedir:/app/dev $PACKAGE_NAME/$image "$@"
+
+
+

--- a/docker/testall
+++ b/docker/testall
@@ -1,0 +1,9 @@
+#! /bin/bash
+#
+prog=`basename $0`
+execdir=`dirname $0`
+[ "$execdir" = "" -o "$execdir" = "." ] && execdir=$PWD
+export CODEDIR=`(cd $execdir/.. > /dev/null 2>&1; pwd)`
+export DOCKERDIR=$execdir
+
+exec $DOCKERDIR/run.sh testall

--- a/oar-build/README.md
+++ b/oar-build/README.md
@@ -1,0 +1,14 @@
+# oar-build: Build tools for the OAR Platform
+
+The contents of this directory originate from [the oar-build
+repository](https://github.com/usnistgov/oar-build).  It contains
+tools for building an OAR package.  (See
+[../README_OARBUILD.md](https://github.com/usnistgov/oar-build/blob/master/README_OARBUILD.md)
+for information about these tools.)
+
+This directory contains scripts and related data that can be called
+internally by a package's build scripts (found in
+[../scripts](../scripts) and [../docker](../docker)).  Files in this
+directory generally should not by edited; instead, one customizes the
+wrapper scripts that reside in the aforementioned directories.  
+

--- a/oar-build/_dockbuild.sh
+++ b/oar-build/_dockbuild.sh
@@ -1,0 +1,110 @@
+#! /bin/bash
+#
+# Processes command line arguments for dockbuild.sh and defines functions it
+# can use.
+#
+set -e
+true ${prog:=_dockbuild.sh}
+
+[ -z "$codedir" ] && {
+    echo "${prog}: \$codedir is not set."
+    exit 10
+}
+
+true ${OAR_BUILD_DIR:=$codedir/oar-build}
+true ${OAR_DOCKER_DIR:=$codedir/docker}
+true ${PACKAGE_NAME:=`basename $codedir`}
+
+[ -z "$DOCKER_IMAGE_DIRS" ] && {
+    for item in `ls $OAR_DOCKER_DIR`; do
+        [ -d "$item" -a -f "$item/Dockerfile" ] && \
+            DOCKER_IMAGE_DIRS="$DOCKER_IMAGE_DIRS $item"
+    done
+}
+
+LOGFILE=dockbuild.log
+LOGPATH=$PWD/$LOGFILE
+. $OAR_BUILD_DIR/_logging.sh
+
+function sort_build_images {
+    # Determine which images to build
+    #
+    # Input:  list of the requested images (on the command line)
+    #
+    
+    if [ -z "$@" -o "$@" = ":" ]; then
+        # no images are mentioned on the command line, build them all
+        # 
+        out=$DOCKER_IMAGE_DIRS
+
+    else
+        # make sure we build them in the right order
+        # 
+        out=
+        for img in $DOCKER_IMAGE_DIRS; do
+            (echo $@ | grep -qs ":${img}:") && \
+                out="$out $img"
+        done
+    fi
+
+    echo $out
+}
+
+function collect_build_opts {
+    [ -n "$OAR_DOCKER_UID" ] || OAR_DOCKER_UID=`id -u`
+    echo "--build-arg=devuid=$OAR_DOCKER_UID"
+}
+
+function setup_build {
+    BUILD_IMAGES=`sort_build_images $do_BUILD_IMAGES`
+    BUILD_OPTS=`collect_build_opts`
+}
+
+function help {
+    helpfile=$OAR_BUILD_DIR/dockbuild_help.txt
+    [ -f "$OAR_DOCKER_DIR/dockbuild_help.txt" ] && \
+        helpfile=$OAR_DOCKER_DIR/dockbuild_help.txt
+    sed -e "s/%PROG%/$prog/g" $helpfile
+}
+
+CL4LOG=$@
+
+do_BUILD_IMAGES=":"
+while [ "$1" != "" ]; do
+    case "$1" in
+        --logfile=*)
+            LOGPATH=`echo $1 | sed -e 's/[^=]*=//'`
+            ;;
+        -l)
+            shift
+            LOGPATH=$1
+            ;;
+        --quiet|-q)
+            QUIET=-q
+            ;;
+        --help|-h)
+            help
+            exit 0
+            ;;
+        -*)
+            echo "${prog}: unsupported option:" $1 "(should this be placed after cmd?)"
+            false
+            ;;
+        *)
+            do_BUILD_IMAGES="${do_BUILD_IMAGES}${1}:"
+            ;;
+    esac
+    shift
+done
+
+(echo $LOGPATH | egrep -qs '^/') || LOGPATH=$PWD/$LOGPATH
+
+# Set the user that Docker containers should run as.  Be default, this is set
+# to the user running this script so that any files created within the container
+# will be owned by this user (rather than, say, root).
+#
+OAR_DOCKER_UID=`id -u`
+
+# Build from inside the docker dir
+# 
+cd $OAR_DOCKER_DIR

--- a/oar-build/_logging.sh
+++ b/oar-build/_logging.sh
@@ -1,0 +1,36 @@
+#! /bin/bash
+#
+# Defines logging functions
+#
+set -e
+true ${prog:=_logging.sh}
+
+true ${LOGAPPEND:=}                 # can be set by caller
+
+function log_intro {
+    if [ -n "$LOGPATH" ]; then
+        [ -e "$LOGPATH" ] && {
+            if [ -n "$LOGAPPEND" ]; then
+                echo >> $LOGPATH
+                echo '+++++++++++++++++++++++++++++++++++++++++++++' >> $LOGPATH
+            else
+                echo -n > $LOGPATH
+            fi
+        }
+        echo Exec: $prog $CL4LOG >> $LOGPATH
+        echo "  " started at `date` >> $LOGPATH
+    elif [ -n "$QUIET" ]; then
+        echo "${prog}: Warning: log will not be written."
+    fi
+}
+
+function logit {
+    if [ -z "$LOGPATH" ]; then
+        cat
+    elif [ -n "$QUIET" ]; then
+        cat >> $LOGPATH
+    else
+        tee -a $LOGPATH
+    fi
+}
+

--- a/oar-build/_run.sh
+++ b/oar-build/_run.sh
@@ -1,0 +1,98 @@
+#! /bin/bash
+#
+# Processes command line arguments for run.sh and defines functions it
+# can use.
+#
+set -e
+true ${prog:=_run.sh}
+
+[ -z "$PACKAGE_DIR" ] && {
+    echo "${prog}: \$PACKAGE_DIR is not set."
+    exit 10
+}
+
+true ${OAR_BUILD_DIR:=$PACKAGE_DIR/oar-build}
+true ${OAR_DOCKER_DIR:=$PACKAGE_DIR/docker}
+true ${RM:=}
+
+true ${PACKAGE_NAME:=`basename $PACKAGE_DIR`}
+true ${SHELL_COMMANDS:="bshell shell"}
+
+LOGFILE=run.log
+LOGPATH=$PWD/$LOGFILE
+. $OAR_BUILD_DIR/_logging.sh
+
+function set_interactive {
+    shcmds=:`echo $SHELL_COMMANDS | sed -re 's/ +/:/'`:
+    cmd=$1
+    [ -z "$cmd" ] && cmd=build
+
+    INTERACTIVE=
+    if (echo $shcmds | grep -qs :${cmd}:); then
+        INTERACTIVE=-ti
+    else
+        true
+    fi
+}
+
+function collect_run_opts {
+    RUN_OPTS="$RM -e PACKAGE_NAME=$PACKAGE_NAME -v ${PACKAGE_DIR}:/dev/$PACKAGE_NAME"
+}
+
+function setup_run {
+    set_interactive
+    collect_run_opts
+}
+
+function build_images {
+    echo '+' buildall.sh $QUIET
+    $OAR_DOCKER_DIR/buildall.sh $QUIET
+}
+
+function help {
+    helpfile=$OAR_BUILD_DIR/run_help.txt
+    [ -f "$OAR_DOCKER_DIR/run_help.txt" ] && \
+        helpfile=$OAR_DOCKER_DIR/run_help.txt
+    sed -e "s/%PROG%/$prog/g" $helpfile
+}
+
+CL4LOG=$@
+
+while [ "$1" != "" ]; do
+    case "$1" in
+        --logfile=*)
+            LOGPATH=`echo $1 | sed -e 's/[^=]*=//'`
+            ;;
+        -l)
+            shift
+            LOGPATH=$1
+            ;;
+        --quiet|-q)
+            QUIET=-q
+            ;;
+        --no-remove|-R)
+            RM=
+            ;;
+        --build|-b)
+            BUILD_FIRST=1
+            ;;
+        --help|-h)
+            help
+            exit 0
+            ;;
+        -*)
+            echo "${prog}: unsupported option:" $1 "(should this be placed after cmd?)"
+            false
+            ;;
+        *)
+            # remainder of arguments will be passed to entrypoint script
+            break
+            ;;
+    esac
+    shift
+done
+[ $# -eq 0 ] && set -- "build"
+
+(echo $LOGPATH | egrep -qs '^/') || LOGPATH=$PWD/$LOGPATH
+
+    

--- a/oar-build/_setversion.sh
+++ b/oar-build/_setversion.sh
@@ -1,0 +1,90 @@
+#! /bin/bash
+#
+# Processes command line arguments for setversion.sh and defines functions it
+# can use.
+#
+set -e
+true ${prog:=_setversion.sh}
+
+function get_reponame {
+    if [ -n "$GIT_COMMIT" ]; then
+        remotes=(`git remote show -n`)
+        repo=`git remote show -n ${remotes[0]} | grep Fetch | sed -e 's/^.*://'`
+        basename $repo .git
+    elif [ -n "$PACKAGE_DIR" ]; then
+        if [ -f "$PACKAGE_DIR/VERSION" ]; then
+            awk '{print $1}' "$PACKAGE_DIR/VERSION"
+        else
+            basename $PACKAGE_DIR | sed -re '/^oar-[^\-]+-/ s/-[^\-]+$//'
+        fi
+    else
+        echo ${prog}: Not a git repository; unable to determine package name
+        false
+    fi
+}
+
+function get_branchname {
+    if [ -n "$GIT_COMMIT" ]; then
+        branch=`git rev-parse --abbrev-ref HEAD`
+        echo $branch
+    elif (basename "$PACKAGE_DIR" | grep -sqP '^oar-[^\-]+-'); then
+        basename "$PACKAGE_DIR" | sed -re 's/^.*-//'
+    else
+        echo "(unknown)"
+    fi
+}
+
+function get_commit {
+    git rev-parse HEAD 2> /dev/null || true
+}
+
+function get_tag {
+    if [ -n "$GIT_COMMIT" ]; then
+        opts=--tags
+        #opts=
+        errfile=/tmp/git-describe-$$_err.txt
+        git describe $opts 2> $errfile || {
+            grep -qs 'No names found' $errfile || {
+                echo setversion: git describe failed: 1>&2
+                cat $errfile 1>&2
+                rm $errfile
+                false
+            }
+            rm $errfile
+        }
+    fi
+}
+
+# return a string that represents a version of software.  If the last
+# commit has an associated tag, that is returned.  Otherwise, one is
+# constructed from a the current branch and commit.  
+function determine_version {
+    out=`get_tag`
+    [ -z "$out" ] && {
+        out=`get_branchname`
+        commit=`get_commit`
+        [ -n "$commit" ] && out="${out}-${commit:0:8}"
+    }
+    echo $out
+}
+
+function write_VERSION {
+    if [ -z "$PACKAGE_DIR" ]; then
+        echo ${prog}: state error: PACKAGE_DIR not set
+        false
+    else
+        echo $1 $2 > $PACKAGE_DIR/VERSION
+    fi
+}
+
+function set_pkg_version {
+    pkg=$1; shift
+    vers=$1; shift
+    [ -z "$vers" ] && vers=`determine_version`
+    [ -z "$pkg" ] && pkg=`get_reponame`
+    write_VERSION $pkg $vers
+}
+
+GIT_COMMIT=`get_commit`
+[ -n "$PACKAGE_NAME" ] || PACKAGE_NAME=$(get_reponame)
+

--- a/oar-build/bundle_dist.sh
+++ b/oar-build/bundle_dist.sh
@@ -1,0 +1,20 @@
+#! /bin/bash
+#
+# bundle_dist.sh:  bundle up the data products in the dist directory into a
+#                  zip file
+#
+prog=`basename $0`
+execdir=`dirname $0`
+[ "$execdir" = "" -o "$execdir" = "." ] && execdir=$PWD
+codedir=`(cd $execdir/.. > /dev/null 2>&1; pwd)`
+distdir=$codedir/dist
+
+true ${PACKAGE_NAME:=`basename $codedir`}
+true ${DIST_BUNDLE:=${PACKAGE_NAME}-dist.zip}
+
+distpath=$codedir/$DIS_BUNDLE
+
+set -e
+cd $distdir
+set -x
+zip -r $distpath *

--- a/oar-build/dockbuild_help.txt
+++ b/oar-build/dockbuild_help.txt
@@ -1,0 +1,12 @@
+
+%PROG% -- Build all (or requested) docker images found in the docker directory
+
+Usage: %PROG% [-lq] [image_dir ...]
+
+Options:
+   --logfile=FILEPATH, -l FILEPATH   Log file to record build output to
+   --quiet, -q                       Suppress messages to terminal
+
+Arguments:
+   image_dir ...      names of docker directories for the images that should 
+                      (re-)build; only these will be built.

--- a/oar-build/run_help.txt
+++ b/oar-build/run_help.txt
@@ -1,0 +1,19 @@
+
+Usage: $prog [-lq] [cmd [cmd_options]]
+
+Options:
+   --no-remove, -r                   Don't remove container after exiting
+   --logfile=FILEPATH, -l FILEPATH   Log file to record build output to
+   --quiet, -q                       Suppress messages to terminal
+
+Arguments:
+   cmd     The command to run in the container; one of
+              $RUN_COMMANDS
+
+Commands:
+   build   Build the package and write build products into a zip file
+             called PACKAGE-dist.zip
+   test    Build the build products and run all unit tests
+   bshell  Build the build products and then start an interactive shell
+   shell   Start an interactive shell (without building anything first)
+

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
 					<groupId>org.springframework.boot</groupId>
 					<artifactId>spring-boot-maven-plugin</artifactId>
 				</plugin>
-<plugin>
+                                <plugin>
                                         <artifactId>maven-dependency-plugin</artifactId>
                                         <version>2.8</version>
                                         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,23 @@
 					<groupId>org.springframework.boot</groupId>
 					<artifactId>spring-boot-maven-plugin</artifactId>
 				</plugin>
+<plugin>
+                                        <artifactId>maven-dependency-plugin</artifactId>
+                                        <version>2.8</version>
+                                        <executions>
+                                            <execution>
+                                                <id>analyze</id>
+                                                <goals>
+                                                    <goal>analyze-only</goal>
+                                                </goals>
+                                                <configuration>
+                                                    <failOnWarning>true</failOnWarning>
+                                                    <outputXML>true</outputXML>
+                                                    <scriptableOutput>true</scriptableOutput>
+                                                </configuration>
+                                            </execution>
+                                        </executions>
+                                    </plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>

--- a/scripts/makedist
+++ b/scripts/makedist
@@ -7,7 +7,7 @@ prog=`basename $0`
 execdir=`dirname $0`
 [ "$execdir" = "" -o "$execdir" = "." ] && execdir=$PWD
 PACKAGE_DIR=`(cd $execdir/.. > /dev/null 2>&1; pwd)`
-distdir=$PACKAGE_DIR/dist
+DIST_DIR=$PACKAGE_DIR/dist
 targetdir=$PACKAGE_DIR/target
 
 # Update this list with the names of the individual component names
@@ -57,8 +57,6 @@ java_major_version=`echo $java_version | sed -re 's/^[0-9]+\.//' -e 's/[\.\-\_].
     false
 }
 
-mkdir -p $distdir
-
 # set the current version.  This will inject the version into the code, if 
 # needed.
 #
@@ -81,14 +79,14 @@ mvn clean package
 # ENTER COMMANDS for creating the dependency file(s)
 #
 # A dependency file should be called DISTNAME-${version}_dep.json
-mkdir -p $distdir
+mkdir -p $DIST_DIR
 mvn dependency:tree -DoutputType=dot -DoutputFile=target/deptree.dot
 $PACKAGE_DIR/scripts/record_deps.py ${DISTNAMES[0]} $version \
-                                 > $distdir/${DISTNAMES[0]}-${vers4fn}_dep.json
+                                 > $DIST_DIR/${DISTNAMES[0]}-${vers4fn}_dep.json
 
 # ENTER COMMANDS for bundling (or renaming) the distribution, if needed
 #
 # A distribution file should be called DISTNAME-${vers4fn}.DISTEXT
 #
-cp $targetdir/${DISTNAMES[0]}.jar $distdir/${DISTNAMES[0]}-$vers4fn.jar
+cp $targetdir/${DISTNAMES[0]}.jar $DIST_DIR/${DISTNAMES[0]}-$vers4fn.jar
 

--- a/scripts/makedist
+++ b/scripts/makedist
@@ -1,0 +1,91 @@
+#! /bin/bash
+#
+# build.sh:  build the package
+#
+set -e
+prog=`basename $0`
+execdir=`dirname $0`
+[ "$execdir" = "" -o "$execdir" = "." ] && execdir=$PWD
+PACKAGE_DIR=`(cd $execdir/.. > /dev/null 2>&1; pwd)`
+distdir=$PACKAGE_DIR/dist
+targetdir=$PACKAGE_DIR/target
+
+# Update this list with the names of the individual component names
+# 
+DISTNAMES=(oar-rmm-service)
+
+# handle command line options
+MAKEDIST=
+while [ "$1" != "" ]; do 
+  case "$1" in
+    --dist-dir=*)
+        DIST_DIR=`echo $1 | sed -e 's/[^=]*=//'`
+        ;;
+    --dist-dir)
+        shift
+        DIST_DIR=$1
+        ;;
+    --source-dir=*|--dir=*)
+        PACKAGE_DIR=`echo $1 | sed -e 's/[^=]*=//'`
+        ;;
+    -d|--dir|--source-dir)
+        shift
+        PACKAGE_DIR=$1
+        ;;
+    -*)
+        echo "$prog: unsupported option:" $1
+        false
+        ;;
+    *)
+        (echo :${DISTNAMES[@]}: | sed -e 's/ /:/g' | grep -qs :${1}:) || {
+            echo "${prog}: ${1}: unrecognized distribution name"
+            false
+        }
+        MAKEDIST="$MAKEDIST $1"
+        ;;
+  esac
+  shift
+done
+[ -n "$MAKEDIST" ] || MAKEDIST=${DISTNAMES[@]}
+
+true ${DIST_DIR:=$SOURCE_DIR/dist}
+
+java_version=`javac -version 2>&1 | awk '{print $2}'`
+java_major_version=`echo $java_version | sed -re 's/^[0-9]+\.//' -e 's/[\.\-\_].*//'`
+[ "$java_major_version" -ge 8 ] || {
+    echo "${prog}: Java 8 required to make distributions (found $java_version)"
+    false
+}
+
+mkdir -p $distdir
+
+# set the current version.  This will inject the version into the code, if 
+# needed.
+#
+$PACKAGE_DIR/scripts/setversion.sh
+[ -n "$PACKAGE_NAME" ] || PACKAGE_NAME=`cat VERSION | awk '{print $1}'`
+version=`cat VERSION | awk '{print $2}'`
+vers4fn=`echo $version | sed -re 's#[/\s]+#_#g'`
+
+
+# ENTER BUILD COMMANDS HERE
+#
+# The build products should be written into the "dist" directory
+mvn clean package
+[ -f "$targetdir/${DISTNAMES[0]}.jar" ] || {
+    echo "${prog}:" Failed to build distribution: \
+         "$targetdir/${DISTNAMES[0]}.jar"
+    false
+}
+
+# ENTER COMMANDS for creating the dependency file(s)
+#
+# A dependency file should be called DISTNAME-${version}_dep.json
+mkdir -p $distdir
+
+# ENTER COMMANDS for bundling (or renaming) the distribution, if needed
+#
+# A distribution file should be called DISTNAME-${vers4fn}.DISTEXT
+#
+cp $targetdir/${DISTNAMES[0]}.jar $distdir/${DISTNAMES[0]}-$vers4fn.jar
+

--- a/scripts/makedist
+++ b/scripts/makedist
@@ -63,7 +63,7 @@ mkdir -p $distdir
 # needed.
 #
 $PACKAGE_DIR/scripts/setversion.sh
-[ -n "$PACKAGE_NAME" ] || PACKAGE_NAME=`cat VERSION | awk '{print $1}'`
+[ -n "$PACKAGE_NAME" ] || export PACKAGE_NAME=`cat VERSION | awk '{print $1}'`
 version=`cat VERSION | awk '{print $2}'`
 vers4fn=`echo $version | sed -re 's#[/\s]+#_#g'`
 
@@ -82,6 +82,9 @@ mvn clean package
 #
 # A dependency file should be called DISTNAME-${version}_dep.json
 mkdir -p $distdir
+mvn dependency:tree -DoutputType=dot -DoutputFile=target/deptree.dot
+$PACKAGE_DIR/scripts/record_deps.py ${DISTNAMES[0]} $version \
+                                 > $distdir/${DISTNAMES[0]}-${vers4fn}_dep.json
 
 # ENTER COMMANDS for bundling (or renaming) the distribution, if needed
 #

--- a/scripts/makedist.docker
+++ b/scripts/makedist.docker
@@ -1,0 +1,10 @@
+#! /bin/bash
+#
+prog=`basename $0`
+execdir=`dirname $0`
+[ "$execdir" = "" -o "$execdir" = "." ] && execdir=$PWD
+export CODEDIR=`(cd $execdir/.. > /dev/null 2>&1; pwd)`
+export DOCKERDIR=$CODEDIR/docker
+
+$DOCKERDIR/dockbuild.sh
+exec $DOCKERDIR/makedist

--- a/scripts/makedist.docker
+++ b/scripts/makedist.docker
@@ -7,4 +7,4 @@ export CODEDIR=`(cd $execdir/.. > /dev/null 2>&1; pwd)`
 export DOCKERDIR=$CODEDIR/docker
 
 $DOCKERDIR/dockbuild.sh
-exec $DOCKERDIR/makedist
+exec $DOCKERDIR/makedist "$@"

--- a/scripts/record_deps.py
+++ b/scripts/record_deps.py
@@ -1,0 +1,119 @@
+#! /usr/bin/python
+#
+# record_deps.py -- encode the dependencies of a distribution as JSON object,
+#                   writing it to standard output.
+#
+# Usage:  record_deps.py DISTNAME VERSION PACKAGE_LOCK_FILE NPMVERSION
+#
+# where,
+#   DISTNAME            the name of the distribution the dependencies apply to
+#   VERSION             the version of the distribution 
+#
+# The default package name (oar-sdp) can be over-ridden by the environment
+# variable PACKAGE_NAME
+#
+from __future__ import print_function
+import os, sys, json, re
+from collections import OrderedDict
+import subprocess as subproc
+import traceback as tb
+
+prog = os.path.basename(sys.argv[0])
+execdir = os.path.dirname(sys.argv.pop(0))
+pkgdir = os.path.dirname(execdir)
+pkgname = os.environ.get('PACKAGE_NAME', 'oar-rmm')
+targetdir = os.path.join(pkgdir, "target")
+
+def usage():
+    print("Usage: %s DISTNAME VERSION" % prog, file=sys.stderr)
+
+def fail(msg, excode=1):
+    print(prog + ": " + msg, file=sys.stderr)
+    sys.exit(excode)
+
+
+class parse_artifact(object):
+    def __init__(self, artstr):
+        if ':' not in artstr:
+            raise ValueError("Not an artifact string: "+artstr)
+        parts = artstr.split(':')
+        self.groupid = parts[0]
+        self.artifactid = parts[1]
+        self.type = parts[2]
+        self.version = parts[3]
+        self.neededfor = (len(parts) > 4 and parts[4]) or None
+
+def parse_deptree(depfile, compname=None):
+    flre = re.compile(r'digraph "([^"]*)" {')
+    depre = re.compile(r'\s*"([^"]*)" -> "([^"]*)"')
+    endre = re.compile(r'\s*}')
+
+    deps = OrderedDict()
+    with open(depfile) as fd:
+        m = flre.match(fd.readline())
+        if not m:
+            raise ValueError("file contents not in DOT (directed graph) format")
+        compstr = m.group(1)
+        comp = parse_artifact(compstr)
+        if compname and comp.artifactid != compname:
+            raise ValueError("Unexpected component described: "+comp.artifactid)
+
+        for line in fd:
+            m = depre.match(line)
+            if m:
+                depfor = m.group(1)
+                if depfor not in deps:
+                    deps[depfor] = []
+                deps[depfor].append(m.group(2))
+                line = line[m.end():]
+            m = endre.match(line)
+            if m:
+                break
+
+    return depsfor(compstr, deps)
+
+def depsfor(artstr, lookup):
+    out = OrderedDict()
+    if artstr in lookup:
+        for dep in lookup[artstr]:
+            comp = parse_artifact(dep)
+            name = comp.groupid+':'+comp.artifactid
+            out[name] = OrderedDict([
+                ("version", comp.version),
+                ("artifacttype", comp.type)
+            ])
+            if comp.neededfor:
+                out[name]['neededfor'] = comp.neededfor
+            if dep in lookup:
+                out[name]['dependencies'] = depsfor(dep, lookup)
+    return out
+
+def make_depdata(compname, pkgver):
+    depfile = os.path.join(targetdir, "deptree.dot")
+    if not os.path.exists(depfile):
+        raise RuntimeError("Missing deptree file: "+depfile)
+    deps = OrderedDict([
+        (pkgname, OrderedDict([ ("version", pkgver) ]))
+    ])
+    deps.update(parse_deptree(depfile, compname))
+
+    data = OrderedDict([
+        ("name", compname),
+        ("version", pkgver),
+        ("dependencies", deps)
+    ])
+    return data
+
+if len(sys.argv) < 2:
+    usage()
+    fail("Missing arguments -- need 2")
+    
+distname = sys.argv.pop(0)
+distvers = sys.argv.pop(0)
+
+try: 
+    data = make_depdata(distname, distvers)
+    json.dump(data, sys.stdout, indent=2)
+except ValueError as ex:
+    fail(str(ex), 2)
+

--- a/scripts/setversion.sh
+++ b/scripts/setversion.sh
@@ -1,0 +1,40 @@
+#! /bin/bash
+#
+# setversion.sh:  build all docker images in this directory
+#
+# Usage: setversion.sh
+#
+# This script can be edited to customize it for its package.
+#
+# set -x
+prog=`basename $0`
+execdir=`dirname $0`
+[ "$execdir" = "" -o "$execdir" = "." ] && execdir=$PWD
+PACKAGE_DIR=`(cd $execdir/.. > /dev/null 2>&1; pwd)`
+set -e
+
+## This is set by default via _setversion.sh; if necessary, uncomment 
+#  and customize
+# 
+# PACKAGE_NAME=oar-build
+
+. $PACKAGE_DIR/oar-build/_setversion.sh
+
+version=$(determine_version)
+
+# write the package name and version to file called VERSION
+# don't overwrite VERSION if this is not a cloned repo
+if [ -n "$GIT_COMMIT" -o ! -e VERSION ]; then
+    write_VERSION $PACKAGE_NAME $version
+else
+    [ -n "$PACKAGE_NAME" ] || PACKAGE_NAME=`cat VERSION | awk '{print $1}'`
+    version=`cat VERSION | awk '{print $2}'`
+fi
+
+# inject the version string into the source code
+#
+[ ! -e "$PACKAGE_DIR/scripts/inject_version.sh" ] || {
+    bash "$PACKAGE_DIR/scripts/inject_version.sh" $version $PACKAGE_NAME
+}
+
+# echo $PACKAGE_NAME $version

--- a/scripts/testall
+++ b/scripts/testall
@@ -1,0 +1,12 @@
+#! /bin/bash
+#
+# testall:  run all package tests
+#
+set -e
+prog=`basename $0`
+execdir=`dirname $0`
+[ "$execdir" = "" -o "$execdir" = "." ] && execdir=$PWD
+PACKAGE_DIR=`(cd $execdir/.. > /dev/null 2>&1; pwd)`
+
+$PACKAGE_DIR/scripts/setversion.sh
+mvn test

--- a/scripts/testall.docker
+++ b/scripts/testall.docker
@@ -1,0 +1,16 @@
+#! /bin/bash
+#
+prog=`basename $0`
+execdir=`dirname $0`
+[ "$execdir" = "" -o "$execdir" = "." ] && execdir=$PWD
+export CODEDIR=`(cd $execdir/.. > /dev/null 2>&1; pwd)`
+export DOCKERDIR=$CODEDIR/docker
+
+echo '##################################'
+echo '#' 
+echo '# Running tests via docker'
+echo '#' 
+echo '##################################'
+echo '(Assuming docker containers have been built)'
+
+exec $DOCKERDIR/testall


### PR DESCRIPTION
This PR addresses issue [ODD-572 ("localdeploy Pt.2: provide unified docker-based builds in component repos")](https://mml.nist.gov:8080/browse/ODD-572).  It represents the second half of planned development of the localdeploy framework for building OAR applications.  All repos providing components to an `oar-docker` application, including this one, was updated with this framework.  It's key features are:
- Common mechanisms for building distributions from an OAR repository, via the common tools `makedist` (when prerequisites are natively installed) and `makedist.docker` (when they are not).  `localdeploy` uses the latter to build deployable distributions.
- Version tracking: a version string is generated based on `git` tags and branches as part of the (`makedist`) build process and allows that string to be injected into code.  `makedist` will also capture all of the dependency versions for the build and record them into a JSON file (of the form `*_deps.json`).
- All build output performed with `makedist.docker` will be owned by the user; this fixes a problem with the previous `localdeploy` where docker-based builds created files owned by root, making them a pain to delete.  
- Support for TravisCI automated testing

This PR primarily adds a `oar-build` directory containing generic framework files as well as new scripts to the `scripts` directory.  The latter files can be specialized for this package.  The original source for these tools can be found in the [`oar-build`](https://github.com/usnistgov/oar-build) repository.

The best way to test this is by building and locally running `oar-docker` applications; see the corresponding [`oar-docker` PR 95](https://github.com/usnistgov/oar-docker/pull/95) for instructions.