### PR TITLE
Support URLs based on ARK ID-based EDI-IDs

### DIFF
--- a/src/main/java/gov/nist/oar/rmm/config/AppConfig.java
+++ b/src/main/java/gov/nist/oar/rmm/config/AppConfig.java
@@ -38,8 +38,11 @@ public class AppConfig {
 
 	 private static Logger log = LoggerFactory.getLogger(AppConfig.class);
 
-          @Value("${oar.id.ark_naan.default:88434}")
-          public String defnaan;
+          @Value("${oar.id.ark_naan.default}")
+          private String defnaan;
+
+          /** return the default NAAN associated with ARK identifiers in the repository */
+          public String getDefaultNAAN() { return defnaan; }
 
 	  /**
 	   * Main runner of the spring-boot class

--- a/src/main/java/gov/nist/oar/rmm/config/AppConfig.java
+++ b/src/main/java/gov/nist/oar/rmm/config/AppConfig.java
@@ -22,6 +22,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+import org.springframework.beans.factory.annotation.Value;
 
 @SpringBootApplication
 @RefreshScope
@@ -36,6 +37,9 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 public class AppConfig {
 
 	 private static Logger log = LoggerFactory.getLogger(AppConfig.class);
+
+          @Value("${oar.id.ark_naan.default:88434}")
+          public String defnaan;
 
 	  /**
 	   * Main runner of the spring-boot class

--- a/src/main/java/gov/nist/oar/rmm/controllers/SearchController.java
+++ b/src/main/java/gov/nist/oar/rmm/controllers/SearchController.java
@@ -99,7 +99,7 @@ public class SearchController{
 		return repo.find(params);
 	}
 	
-	@RequestMapping(value = {"/records/{ediid}"}, method = RequestMethod.GET,  produces="application/json")
+	@RequestMapping(value = {"/records/{id}"}, method = RequestMethod.GET,  produces="application/json")
 	@ApiOperation(value = "Get NERDm record of given id.",nickname = "recordbyId",
 	  notes = "Resource returns a NERDm Record by given ediid.")
 	/**
@@ -113,7 +113,7 @@ public class SearchController{
 		return repo.findRecord(id);
 	}
 	
-	@RequestMapping(value = {"/records/ark:/{naan:\\d+}/{ediid}"}, method = RequestMethod.GET,  produces="application/json")
+	@RequestMapping(value = {"/records/ark:/{naan:\\d+}/{id}"}, method = RequestMethod.GET,  produces="application/json")
 	@ApiOperation(value = "Get NERDm record of given id.",nickname = "recordbyId",
 	  notes = "Resource returns a NERDm Record by given ediid.")
 	/**

--- a/src/main/java/gov/nist/oar/rmm/controllers/SearchController.java
+++ b/src/main/java/gov/nist/oar/rmm/controllers/SearchController.java
@@ -113,6 +113,22 @@ public class SearchController{
 		return repo.findRecord(ediid);
 	}
 	
+	@RequestMapping(value = {"/records/ark:/{naan:\\d+}/{ediid}"}, method = RequestMethod.GET,  produces="application/json")
+	@ApiOperation(value = "Get NERDm record of given id.",nickname = "recordbyId",
+	  notes = "Resource returns a NERDm Record by given ediid.")
+	/**
+	 * Get record for given id 
+	 * @param id
+	 * @return Returns Document
+	 * @throws IOException
+	 */
+        public Document record(@PathVariable @Valid String ediid, @PathVariable String naan)
+            throws IOException
+        {
+		logger.info("Get record by full ARK id:"+request);
+		return repo.findRecord(ediid);
+	}
+	
 	
 	@RequestMapping(value = {"/records/fields"}, method = RequestMethod.GET,produces="application/json")
 	@ApiOperation(value = "Get all fields in the NERDm records.",nickname = "fieldnames",

--- a/src/main/java/gov/nist/oar/rmm/controllers/SearchController.java
+++ b/src/main/java/gov/nist/oar/rmm/controllers/SearchController.java
@@ -108,9 +108,9 @@ public class SearchController{
 	 * @return Returns Document
 	 * @throws IOException
 	 */
-	public Document record(@PathVariable  @Valid String ediid) throws IOException{
-		logger.info("Get record by id:"+request);
-		return repo.findRecord(ediid);
+	public Document record(@PathVariable  @Valid String id) throws IOException{
+		logger.info("Get record by id: "+id);
+		return repo.findRecord(id);
 	}
 	
 	@RequestMapping(value = {"/records/ark:/{naan:\\d+}/{ediid}"}, method = RequestMethod.GET,  produces="application/json")
@@ -118,14 +118,16 @@ public class SearchController{
 	  notes = "Resource returns a NERDm Record by given ediid.")
 	/**
 	 * Get record for given id 
-	 * @param id
+	 * @param id     the local portion of an ARK identifier to match
+	 * @param naan   the ARK identifier's naming authority number (NAAN)
 	 * @return Returns Document
 	 * @throws IOException
 	 */
-        public Document record(@PathVariable @Valid String ediid, @PathVariable String naan)
+        public Document record(@PathVariable @Valid String id, @PathVariable String naan)
             throws IOException
         {
-		logger.info("Get record by full ARK id:"+request);
+                String ediid = "ark:/"+naan+"/"+id;
+		logger.info("Get record by full ARK id: "+ediid);
 		return repo.findRecord(ediid);
 	}
 	

--- a/src/main/java/gov/nist/oar/rmm/repositories/impl/CustomRepositoryImpl.java
+++ b/src/main/java/gov/nist/oar/rmm/repositories/impl/CustomRepositoryImpl.java
@@ -122,7 +122,7 @@ public class CustomRepositoryImpl implements CustomRepository {
 		if(count == 0 && useid.length() < 30 && ! useid.startsWith("ark:")) {
                         // allow an ediid be an abbreviation of the ARK ID as specified
                         // by its local portion
-                        useid = "ark:/"+appconfig.defnaan+"/"+ediid;
+                        useid = "ark:/"+appconfig.getDefaultNAAN()+"/"+ediid;
                         logger.info("Searching for "+ediid+" as "+useid);
                         count  = mcollection.count(Filters.eq("ediid", useid));
 		}

--- a/src/main/java/gov/nist/oar/rmm/repositories/impl/CustomRepositoryImpl.java
+++ b/src/main/java/gov/nist/oar/rmm/repositories/impl/CustomRepositoryImpl.java
@@ -104,7 +104,7 @@ public class CustomRepositoryImpl implements CustomRepository {
 	@Override
 	public Document findRecord(String ediid) {
 		
-		Pattern p = Pattern.compile("[^a-z0-9]", Pattern.CASE_INSENSITIVE);
+		Pattern p = Pattern.compile("[^a-z0-9:/-]", Pattern.CASE_INSENSITIVE);
 		Matcher m = p.matcher(ediid);
 		if(m.find()) 
 			throw new IllegalArgumentException("check input parameters.");

--- a/src/main/java/gov/nist/oar/rmm/repositories/impl/CustomRepositoryImpl.java
+++ b/src/main/java/gov/nist/oar/rmm/repositories/impl/CustomRepositoryImpl.java
@@ -122,6 +122,7 @@ public class CustomRepositoryImpl implements CustomRepository {
                         // allow an ediid be an abbreviation of the ARK ID as specified
                         // by its local portion
                         useid = "ark:/"+appconfig.defnaan+"/"+ediid;
+                        logger.debug("Searching for "+ediid+" as "+useid);
                         count  = mcollection.count(Filters.eq("ediid", useid));
 		}
                 if (count == 0) {

--- a/src/main/java/gov/nist/oar/rmm/repositories/impl/CustomRepositoryImpl.java
+++ b/src/main/java/gov/nist/oar/rmm/repositories/impl/CustomRepositoryImpl.java
@@ -117,13 +117,13 @@ public class CustomRepositoryImpl implements CustomRepository {
 
                 String useid = ediid;
 		
-                logger.info("Searching for "+ediid+" as "+useid);
+                logger.debug("Searching for "+ediid+" as "+useid);
 		long count  = mcollection.count(Filters.eq("ediid",useid));
 		if(count == 0 && useid.length() < 30 && ! useid.startsWith("ark:")) {
                         // allow an ediid be an abbreviation of the ARK ID as specified
                         // by its local portion
                         useid = "ark:/"+appconfig.getDefaultNAAN()+"/"+ediid;
-                        logger.info("Searching for "+ediid+" as "+useid);
+                        logger.debug("Searching for "+ediid+" as "+useid);
                         count  = mcollection.count(Filters.eq("ediid", useid));
 		}
                 if (count == 0) {

--- a/src/main/java/gov/nist/oar/rmm/repositories/impl/CustomRepositoryImpl.java
+++ b/src/main/java/gov/nist/oar/rmm/repositories/impl/CustomRepositoryImpl.java
@@ -31,6 +31,7 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;
 
 import gov.nist.oar.rmm.config.MongoConfig;
+import gov.nist.oar.rmm.config.AppConfig;
 import gov.nist.oar.rmm.exceptions.ResourceNotFoundException;
 import gov.nist.oar.rmm.repositories.CustomRepository;
 import gov.nist.oar.rmm.utilities.ProcessRequest;
@@ -46,6 +47,9 @@ public class CustomRepositoryImpl implements CustomRepository {
 	private Logger logger = LoggerFactory.getLogger(CustomRepositoryImpl.class);
 	@Autowired
 	MongoConfig mconfig;
+
+        @Autowired
+        AppConfig appconfig;
 	
 	/* (non-Javadoc)
 	 * @see gov.nist.oar.rmm.repositories.RecordRepository#find()
@@ -104,21 +108,28 @@ public class CustomRepositoryImpl implements CustomRepository {
 	@Override
 	public Document findRecord(String ediid) {
 		
-		Pattern p = Pattern.compile("[^a-z0-9:/-]", Pattern.CASE_INSENSITIVE);
-		Matcher m = p.matcher(ediid);
+		Pattern legal = Pattern.compile("[^a-z0-9:/-]", Pattern.CASE_INSENSITIVE);
+		Matcher m = legal.matcher(ediid);
 		if(m.find()) 
-			throw new IllegalArgumentException("check input parameters.");
+			throw new IllegalArgumentException("Illegal identifier");
 		
 		MongoCollection<Document> mcollection = mconfig.getRecordCollection();
+
+                String useid = ediid;
 		
-		
-		long count  = mcollection.count(Filters.eq("ediid",ediid));
-		if(count == 0) {
-			//return new Document("Message", "No record available for given id.");
-			throw new ResourceNotFoundException("No record available for given id.");
+		long count  = mcollection.count(Filters.eq("ediid",useid));
+		if(count == 0 && useid.length() < 30 && ! useid.startsWith("ark:")) {
+                        // allow an ediid be an abbreviation of the ARK ID as specified
+                        // by its local portion
+                        useid = "ark:/"+appconfig.defnaan+"/"+ediid;
+                        count  = mcollection.count(Filters.eq("ediid", useid));
 		}
-		else
-		return mcollection.find(Filters.eq("ediid",ediid)).first();
+                if (count == 0) {
+                        //return new Document("Message", "No record available for given id.");
+                        throw new ResourceNotFoundException("No record available for given id.");
+                }
+
+		return mcollection.find(Filters.eq("ediid",useid)).first();
 		
 	}
 

--- a/src/main/java/gov/nist/oar/rmm/repositories/impl/CustomRepositoryImpl.java
+++ b/src/main/java/gov/nist/oar/rmm/repositories/impl/CustomRepositoryImpl.java
@@ -117,13 +117,13 @@ public class CustomRepositoryImpl implements CustomRepository {
 
                 String useid = ediid;
 		
-                logger.debug("Searching for "+ediid+" as "+useid);
+                logger.info("Searching for "+ediid+" as "+useid);
 		long count  = mcollection.count(Filters.eq("ediid",useid));
 		if(count == 0 && useid.length() < 30 && ! useid.startsWith("ark:")) {
                         // allow an ediid be an abbreviation of the ARK ID as specified
                         // by its local portion
                         useid = "ark:/"+appconfig.defnaan+"/"+ediid;
-                        logger.debug("Searching for "+ediid+" as "+useid);
+                        logger.info("Searching for "+ediid+" as "+useid);
                         count  = mcollection.count(Filters.eq("ediid", useid));
 		}
                 if (count == 0) {

--- a/src/main/java/gov/nist/oar/rmm/repositories/impl/CustomRepositoryImpl.java
+++ b/src/main/java/gov/nist/oar/rmm/repositories/impl/CustomRepositoryImpl.java
@@ -117,6 +117,7 @@ public class CustomRepositoryImpl implements CustomRepository {
 
                 String useid = ediid;
 		
+                logger.debug("Searching for "+ediid+" as "+useid);
 		long count  = mcollection.count(Filters.eq("ediid",useid));
 		if(count == 0 && useid.length() < 30 && ! useid.startsWith("ark:")) {
                         // allow an ediid be an abbreviation of the ARK ID as specified


### PR DESCRIPTION
This PR is part of a suite of PRs that address [ODD-778](http://mml.nist.gov:8080/browse/ODD-778) which calls for supporting ARK-ID-based EDI IDs. As part of this change, the landing page service needs to support the URL-pattern, `/od/id/`_dsid_, where _dsid_ can either be of the form `ark:/`_naan/localid_ or, simply, _localid_.  This PR helps support this by supporting both of these forms when resolving an identifier to metadata.  

To enable this, the following changes were made:
 *  the pattern for recognizing legal EDI-ID was updated to allow for the new EDI ID form
 *  In the `SearchController`, a new request mapping and function was added to idenfiers of the form, `ark:/`_naan/localid_ (needed since it contains slashes)
 *  If a non-ARK ID that looks like it could be a local-id, a search is made on it by prepending the `ark:/`_naan/_