### PR TITLE
Dependebot security recommendation: up-rev guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>20.0</version>
+			<version>[24.1.1,)</version>
 			<exclusions>
 				<exclusion>
 					<groupId>com.google.guava</groupId>


### PR DESCRIPTION
Dependebot detected our use of a version of the dependency package, guava, that is subject to [a security alert](https://github.com/usnistgov/oar-rmm/network/alert/pom.xml/com.google.guava:guava/open) (of moderate severity).  This PR updates the required version of guava as recommended by the dependebot alert.  