### PR TITLE
Handle open CORS configuration in code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,16 +274,4 @@
 		</plugins>
 	</build>
 
-	<repositories>
-		<repository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/libs-snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
-
-
 </project>

--- a/src/main/java/gov/nist/oar/rmm/config/AppConfig.java
+++ b/src/main/java/gov/nist/oar/rmm/config/AppConfig.java
@@ -62,7 +62,8 @@ public class AppConfig {
 	        return new WebMvcConfigurerAdapter() {
 	            @Override
 	            public void addCorsMappings(CorsRegistry registry) {
-	                registry.addMapping("/**");
+	                registry.addMapping("/**").allowedOrigins("*")
+                                                  .allowCredentials(false);
 	            }
 	        };
 	    }


### PR DESCRIPTION
The RMM provides an open API which clients are free to use directly to search the PDR metadata.  The configuration for stating this in the HTTP headers has previously been handled in the nginx reverse proxy configuration; however, for unclear reasons, this no longer works properly, causing the landing page editor to be unable to fetch the taxonomy terms.  (Newer versions of Chrome now have a stricter policy for handling CORS; this may be the culprit.)  Specifically, the RMM was spitting out two values for the HTTP header `Access-Control-Allow-Origin` ("`*`" and the landing page host) where only one is allowed; Chrome, thus, was rejecting the taxonomy request response.   The RMM's Swing implementation was responsible for spitting out the extra value.  

This PR addresses this problem by shifting the CORS configuration to the Swing-based java code.  `AppConfig`'s CORS configuration was updated to set the header to just "`*`".  `oar-docker` must also be updated to remove the RMM's CORR configuration from the nginx config file (see its `fix/rmm-cors-all` branch).  