### PR TITLE
Replace Travis testing with GitHub Actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,11 @@
-name: testall
-on:   [pull_request, workflow_dispatch]
+name: "scripts/docker update"
+on:
+  push: 
+    branches-ignore: ['main', 'integration']
+    paths:
+      - 'docker/**'
+      - 'scripts/**'
+      - '.github/workflows/**'
 jobs:
   testall:
     runs-on: ubuntu-20.04

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,5 +1,8 @@
-name: testall
-on:   [pull_request, workflow_dispatch]
+name: integration
+on:
+  workflow_dispatch:
+  push:
+    branches: [integration]
 jobs:
   testall:
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
-name: testall
-on:   [pull_request, workflow_dispatch]
+name: main
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
 jobs:
   testall:
     runs-on: ubuntu-20.04

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -1,0 +1,36 @@
+name: source-update
+on:
+  workflow_dispatch:
+  push:
+    branches-ignore: ['main', 'integration']
+    paths:
+      - 'src/**'
+      - 'pom.xml'
+jobs:
+  buildtest:
+    runs-on: ubuntu-20.04
+#    strategy:
+#      matrix:
+#        java: [ '8' ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+
+      - name: Test with Maven
+        run: mvn --batch-mode test
+
+
+  

--- a/.github/workflows/testall.yml
+++ b/.github/workflows/testall.yml
@@ -1,0 +1,22 @@
+name: testall
+on:   [push, pull_request]
+jobs:
+  testall:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@
+
+      - name: Build Containers
+        env:
+          OAR_DOCKERHUB_CRED: ${{ secrets.OAR_DOCKERHUB_CRED }}
+        run: |
+          bash scripts/dhsetup.sh
+          cd docker && bash ./dockbuild.sh
+
+      - name: Run Unit Tests
+        run: cd docker && ./testall
+

--- a/.github/workflows/testall.yml
+++ b/.github/workflows/testall.yml
@@ -8,7 +8,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Docker
-        uses: docker/setup-buildx-action@
+        uses: docker/setup-buildx-action@v1
 
       - name: Build Containers
         env:


### PR DESCRIPTION
This PR introduces configuration of a GitHub Action that replicates the unit testing we did using Travis-CI.  

To test, ensure that the GitHub action check-marks appear in this PR page.  Click on the mark to access the log for the action.  
