### PR TITLE
Update API Description with Contact Email and Remove License Box

### DIFF
--- a/src/main/resources/static/api.json
+++ b/src/main/resources/static/api.json
@@ -2,13 +2,9 @@
     "openapi": "3.0.1",
     "info": {
         "title": "Resource Metadata Management API",
-        "description": "These are set of APIs which return the NIST public data repository related information. First one is the Search and discover API to get the dataset results for given criteria or dataset identifier.  Second is to get different versions of the records or metadata for given dataset. Third one is to get the usage metrics for different datasets",
-        "license": {
-            "name": "NIST Software",
-            "url": "https://www.nist.gov/open/copyright-fair-use-and-licensing-statements-srd-data-software-and-technical-series-publications"
-        },
+        "description": "These are set of APIs which return the NIST public data repository related information. First one is the Search and discover API to get the dataset results for given criteria or dataset identifier. Second is to get different versions of the records or metadata for given dataset. Third one is to get the usage metrics for different datasets. For any inquiries, please contact the support team at datasupport@nist.gov.",
         "version": "1.1.0"
-    },
+    },      
     "servers": [
         {
             "url": "https://data.nist.gov/rmm",

--- a/src/main/resources/static/api.json
+++ b/src/main/resources/static/api.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "Resource Metadata Management API",
         "description": "These are set of APIs which return the NIST public data repository related information. First one is the Search and discover API to get the dataset results for given criteria or dataset identifier. Second is to get different versions of the records or metadata for given dataset. Third one is to get the usage metrics for different datasets. For any inquiries, please contact the support team at datasupport@nist.gov.",
-        "version": "1.1.0"
+        "version": "1.2.4"
     },      
     "servers": [
         {


### PR DESCRIPTION
This PR includes the following changes:

**1. Added a contact email to the API description:**

- The contact email `datasupport@nist.gov` was added to the end of the description field in the info section of the OpenAPI spec.
- The updated description is:
`"These are set of APIs which return the NIST public data repository related information. First one is the Search and discover API to get the dataset results for given criteria or dataset identifier. Second is to get different versions of the records or metadata for given dataset. Third one is to get the usage metrics for different datasets. For any inquiries, please contact the support team at datasupport@nist.gov."`

**2. Removed the license box from the spec:**

- The license field, that includes the `name`, `url`, and `identifier`, was removed from the OpenAPI spec to prevent buggy rendering of the license box. Ticket regarding this bug can be found [here](https://github.com/stoplightio/elements/issues/2711).

These changes were tested locally.

<img width="1676" alt="image" src="https://github.com/user-attachments/assets/c6f9e448-9bab-4245-a749-b2c7637b16d8">
